### PR TITLE
Make "make install" fully respect PREFIX and DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ all: install
 
 install:
 	install -D -m 0755 $(PROJECT).sh $(DESTDIR)$(PREFIX)/bin/$(PROJECT)
-	install -D -o0 -g0 -m0644 $(PROJECT).man /usr/local/man/man7/$(PROJECT).7
-	gzip -f /usr/local/man/man7/$(PROJECT).7
+	install -D -m 0644 $(PROJECT).man $(DESTDIR)$(PREFIX)/man/man7/$(PROJECT).7
+	gzip -f $(DESTDIR)$(PREFIX)/man/man7/$(PROJECT).7


### PR DESCRIPTION
Previously only the first line of the `install` target was respecting these variables, defeating their purpose. I also removed the `-o` and `-g` flags from the second `install(1)` call because I see no reason to use them both when installing as a user (they won't work anyway) and when installing as root (root will be the owner anyway).